### PR TITLE
Improve cleanup commands

### DIFF
--- a/de.haeckerfelix.AudioSharing.json
+++ b/de.haeckerfelix.AudioSharing.json
@@ -16,6 +16,12 @@
     "build-options" : {
         "append-path" : "/usr/lib/sdk/rust-stable/bin"
     },
+    "cleanup": [
+        "/include",
+        "/lib/girepository-1.0",
+        "/lib/pkgconfig",
+        "/share/gir-1.0"
+    ],
     "modules": [
         {
             "name": "gst-rtsp-server",


### PR DESCRIPTION
Use cleanup commands to reduce the Flatpak size

```
196K	./include
64K    	./lib/girepository-1.0
4,0K	./lib/pkgconfig
820K	./share/gir-1.0
```